### PR TITLE
Remove should from shmock.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var express = require("express");
 var methods = require("methods");
-var should = require("should");
+var assert = require('assert');
 var querystring = require("querystring");
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
@@ -109,17 +109,17 @@ Assertion.prototype.reply = function(status, responseBody) {
 
   this.app[this.method](this.path, function(req, res) {
     if(self.qs) {
-      req.query.should.eql(self.qs);
+      assert.deepEqual(req.query, self.qs);
     }
     if(self.requestBody) {
       if(req.text) {
-        req.text.should.eql(self.requestBody);
+        assert.deepEqual(req.text, self.requestBody);
       } else {
-        req.body.should.eql(self.requestBody);
+        assert.deepEqual(req.body, self.requestBody);
       }
     }
     for(var name in self.headers) {
-      req.headers[name].should.eql(self.headers[name]);
+      assert.deepEqual(req.headers[name], self.headers[name]);
     }
 
     var reply = function() {


### PR DESCRIPTION
When using shmock it requires should. This may cause some version incompatibility because it overwrites user's should if any.

For example when using should 4.0.4 and shmock, should is replaced with shmock's 1.2.2 version.
