### PR TITLE
add a count() method to Handler (+version bump)

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ function Assertion(app, method, path) {
   this.method = method;
   this.path = path;
   this.headers = {};
-  this.isDone = false;
   this.removeWhenMet = true;
 
   this.parseExpectedRequestBody = function() {
@@ -148,8 +147,10 @@ function Handler(assertion) {
   var self = this;
   this.assertion = assertion;
   this.isDone = false;
+  this.responseCount = 0;
   this.on("done", function() {
     self.isDone = true;
+    self.responseCount++;
   });
 }
 
@@ -159,6 +160,10 @@ Handler.prototype.done = function() {
   if(!this.isDone) {
     throw new Error(this.assertion.method + " " + this.assertion.path + " was not made yet.");
   }
+}
+
+Handler.prototype.count = function() {
+  return this.responseCount;
 }
 
 Handler.prototype.wait = function(ms, fn) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shmock",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Simple HTTP Mocking library",
   "keywords": [
     "express",

--- a/test/shmock.js
+++ b/test/shmock.js
@@ -50,6 +50,18 @@ describe("shmock", function() {
       });
     });
 
+    it("Should count responses made by same assertion", function(done) {
+      var handler = mock.get("/persisted").persist().reply(200);
+
+      test.get("/persisted").expect(200, function() {
+        handler.count().should.equal(1);
+        test.get("/persisted").expect(200).end(function(error, response) {
+          handler.count().should.equal(2);
+          done();
+        });     
+      });
+    });
+
     it("Should return a handler to verify if a request has been made", function(done) {
       var handler = mock.get("/foo").reply(200);
 


### PR DESCRIPTION
Hi Jonathan,

Thanks for the code! I am using it add work and added a very simple addition.
I have a use case where I want to know how many times a call to a persistent Assertion is made.
I find the count() method is easier than adding three (example) Assertions and verifying that each one was called via Handler.done().

I am not tied to variable or function names so change away.

Thanks
Kyle
