### PR TITLE
Differentiate by query param

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var querystring = require("querystring");
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
+var deepEqual = require('deep-equal');
 
 module.exports = function(port) {
   var app = express();
@@ -85,11 +86,15 @@ Assertion.prototype.query = function(qs) {
   return this;
 }
 
+Assertion.prototype.ifQuery = function(queryObject) {
+  this.queryObject = queryObject;
+  return this;
+}
+
 Assertion.prototype.set = function(name, value) {
   this.headers[name.toLowerCase()] = value;
   return this;
 }
-
 
 Assertion.prototype.delay = function(ms) {
   this.delay = ms;
@@ -101,44 +106,53 @@ Assertion.prototype.persist = function() {
   return this;
 }
 
-Assertion.prototype.reply = function(status, responseBody) {
+Assertion.prototype.reply = Assertion.prototype.thenReply = function(status, responseBody) {
   this.parseExpectedRequestBody();
 
   var self = this;
+  this.app[this.method](this.path, function(req, res, next) {
+    self.testAssertions(req);
 
-  this.app[this.method](this.path, function(req, res) {
-    if(self.qs) {
-      assert.deepEqual(req.query, self.qs);
+    if (self.queryObject && !deepEqual(req.query,self.queryObject)) {
+      next();
     }
-    if(self.requestBody) {
-      if(req.text) {
-        assert.deepEqual(req.text, self.requestBody);
+    else {
+      var reply = function() {
+          self.handler.emit("done");
+  
+          // Remove route from express since the expectation was met
+          // Unless this mock is suposed to persist
+          if (self.removeWhenMet) self.app._router.map[self.method].splice(req._route_index, 1);
+          res.status(status).send(responseBody);
+        };
+      if(self.delay) {
+        setTimeout(reply, self.delay);
       } else {
-        assert.deepEqual(req.body, self.requestBody);
+        reply();
       }
-    }
-    for(var name in self.headers) {
-      assert.deepEqual(req.headers[name], self.headers[name]);
-    }
-
-    var reply = function() {
-        self.handler.emit("done");
-
-        // Remove route from express since the expectation was met
-        // Unless this mock is suposed to persist
-        if (self.removeWhenMet) self.app._router.map[self.method].splice(req._route_index, 1);
-        res.status(status).send(responseBody);
-      };
-    if(self.delay) {
-      setTimeout(reply, self.delay);
-    } else {
-      reply();
     }
   });
 
   this.handler = new Handler(this);
   return this.handler;
 }
+
+Assertion.prototype.testAssertions = function(req) {
+  if(this.qs) {
+    assert.deepEqual(req.query, this.qs);
+  }
+  if(this.requestBody) {
+    if(req.text) {
+      assert.deepEqual(req.text, this.requestBody);
+    } else {
+      assert.deepEqual(req.body, this.requestBody);
+    }
+  }
+  for(var name in this.headers) {
+    assert.deepEqual(req.headers[name], this.headers[name]);
+  }
+}
+
 
 function Handler(assertion) {
   this.defaults = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shmock",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Simple HTTP Mocking library",
   "keywords": [
     "express",
@@ -10,7 +10,8 @@
   ],
   "dependencies": {
     "express": "~3.4.8",
-    "methods": "~0.1.0"
+    "methods": "~0.1.0",
+    "deep-equal": "0.2.1"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/test/shmock.js
+++ b/test/shmock.js
@@ -27,18 +27,17 @@ describe("shmock", function() {
       mock.clean();
     });
 
-
     it("Should remove by default expectations after meeting them", function(done) {
       var handler = mock.get("/foo").reply(200);
-
+ 
       test.get("/foo").expect(200, function() {
         test.get("/foo").expect(404, done);
       });
     });
-
+ 
     it("Should not remove expectations after meeting them if they were persisted", function(done) {
       var handler = mock.get("/persisted").persist().reply(200);
-
+ 
       test.get("/persisted").expect(200, function() {
         test.get("/persisted").expect(200).end(function(error, response) {
           test.get("/persisted").expect(200).end(function(error, response) {
@@ -52,7 +51,7 @@ describe("shmock", function() {
 
     it("Should count responses made by same assertion", function(done) {
       var handler = mock.get("/persisted").persist().reply(200);
-
+ 
       test.get("/persisted").expect(200, function() {
         handler.count().should.equal(1);
         test.get("/persisted").expect(200).end(function(error, response) {
@@ -61,44 +60,44 @@ describe("shmock", function() {
         });     
       });
     });
-
+ 
     it("Should return a handler to verify if a request has been made", function(done) {
       var handler = mock.get("/foo").reply(200);
-
+ 
       handler.isDone.should.not.be.ok;
       handler.done.should.throw();
-
+ 
       test.get("/foo").expect(200, function() {
         handler.isDone.should.be.ok;
         done();
       });
     });
-
+ 
     it("Should be able to mock a any http method", function(done) {
       mock.get("/foo").reply(200);
-
+ 
       test.get("/foo").expect(200, done);
     });
-
+ 
     it("Should fail if expected request body doesn't match", function(done) {
       mock.get("/foo").send("foobar").reply(200);
-
+ 
       test.get("/foo").end.should.throw();
       done();
     });
-
+ 
     it("Should succeed if expected request body match the one sent", function(done) {
       mock.post("/get").send("lalalala").set("Content-Type", "text/plain").reply(200);
-
+ 
       test.post("/get").set("Content-Type", "text/plain").send("lalalala").expect(200, done);
     });
-
+ 
     it("Should succeed if expected request json match the one sent", function(done) {
       mock.post("/get").send({foo: "bar", bar: "foo"}).reply(200);
-
+ 
       test.post("/get").send({bar: "foo", foo: "bar"}).expect(200, done);
     });
-
+ 
     it("Should match query parameters", function(done) {
       mock.post("/get")
         .query({total: 10, limit: 1})
@@ -106,52 +105,75 @@ describe("shmock", function() {
         .query("a=b&c=d")
         .query("x=y")
         .reply(200);
-
+ 
       test.post("/get").query({total: 10, limit: 1, foo: "bar", a: "b", c: "d", x: "y"}).expect(200, done);
+    });
+ 
+    it("Should match ifQuery parameters", function(done) {
+      mock.post("/get_query")
+        .persist().ifQuery({param1: "request1"})
+        .thenReply(200, {name: "response1"});
+
+      mock.post("/get_query")
+        .persist().ifQuery({param1: "request2"})
+        .thenReply(200, {name: "response2"});
+
+      test.post("/get_query").query({param1: "request1"}).expect(200).end(function(error, response) {
+        response.body.name.should.equal("response1");
+      });
+  
+      test.post("/get_query").query({param1: "request2"}).expect(200).end(function(error, response) {
+        response.body.name.should.equal("response2");
+      });
+  
+      test.post("/get_query").query({param1: "unmatched"}).expect(404).end(function(error, response) {
+        response.status.should.equal(404);
+        done();
+      });
     });
 
     it("Should fail if headers are not matched", function(done) {
       mock.post("/get").set("Content-Type", "application/json").reply(200);
-
+ 
       test.post("/get").end.should.throw();
       done();
     });
-
+ 
     it("Should succeed if headers are matched", function(done) {
       mock.post("/get").set("Content-Type", "application/json").reply(200);
-
+ 
       test.post("/get").set("Content-Type", "application/json").send({}).expect(200, done);
     });
-
+ 
     it("Should be able to wait a specificed number of ms for expectation to be met", function(done) {
       var h = mock.get("/foo").reply(200);
-
+ 
       setTimeout(function() {
         test.get("/foo").expect(200, function() {});
       }, 20);
-
+ 
       h.wait(10, function(err) {
         err.should.not.be.null;
-
+ 
         h.wait(30, done);
       });
     });
-
+ 
     it("Should be able to wait a default number of ms for expectation to be met", function(done) {
       var h = mock.get("/foo").reply(200);
-
+ 
       h.defaults.waitTimeout = 10;
-
+ 
       setTimeout(function() {
         test.get("/foo").expect(200, function() {});
       }, 20);
-
+ 
       h.wait(function(err) {
         err.should.not.be.null;
         done();
       });
     });
-
+ 
     it("Should be able to delay a reply for a specified amount of ms", function(done) {
       mock.get("/foo").delay(30).reply(200);
 


### PR DESCRIPTION
I have added a solution for Issue #2.
Currently we cannot register two persistent Assertions that vary only by the request query parameters.
If we did so the first Assertions would always be called, and if it did not match the query params then the Assertion would throw an exception, which does not give the second Assertion a chance to match.

In the new branch, the assertions will pass via next() to the next assertion, allowing the correct response to be selected.

I wanted to be backwards compatible, so I did not change the existing .query() method. As a result the Assertion API can be confusing (i.e. what is diff between .query() and ifQuery()). An alternative is reuse .query but add an additional API call that will change the error handling mode from 'raise exception' to 'pass' .   

Note that this pull request also includes  the codes from pull request #6 (which is a much smaller change) to add a count() method to the handler.
