### PR TITLE
Fix delay variable name to avoid shadowing delay() fx

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ Assertion.prototype.set = function(name, value) {
 
 
 Assertion.prototype.delay = function(ms) {
-  this.delay = ms;
+  this.delay_ms = ms;
   return this;
 }
 
@@ -130,8 +130,8 @@ Assertion.prototype.reply = function(status, responseBody) {
         if (self.removeWhenMet) self.app._router.map[self.method].splice(req._route_index, 1);
         res.status(status).send(responseBody);
       };
-    if(self.delay) {
-      setTimeout(reply, self.delay);
+    if(self.delay_ms) {
+      setTimeout(reply, self.delay_ms);
     } else {
       reply();
     }


### PR DESCRIPTION
This shadowing caused some race conditions if multiple requests were made at the same time because reply() was made always async allowing to some requests to be handled before expectation was met and removed from the router. 
