### PR TITLE
Add support for setting response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ mock.get("/foo").reply(200, "bar");
 mock.get("/foo").set("Authorization", "123456").reply(200, "bar");
 ```
 
+#### Specifying response headers
+
+```js
+mock.get("/foo").set("Authorization", "123456").reply(200, "bar", {"X-my-header", "My header value"});
+```
+
 #### On querystring parameters
 
 ```js

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ Assertion.prototype.persist = function() {
   return this;
 }
 
-Assertion.prototype.reply = function(status, responseBody) {
+Assertion.prototype.reply = function(status, responseBody, responseHeaders) {
   this.parseExpectedRequestBody();
 
   var self = this;
@@ -131,12 +131,17 @@ Assertion.prototype.reply = function(status, responseBody) {
       assert.deepEqual(req.headers[name], self.headers[name]);
     }
 
+    if(responseHeaders) {
+      res.set(responseHeaders);
+    }
+
     var reply = function() {
         self.handler.emit("done");
 
         // Remove route from express since the expectation was met
         // Unless this mock is suposed to persist
         if (self.removeWhenMet) self.app._router.map[self.method].splice(req._route_index, 1);
+
         res.status(status).send(responseBody);
       };
     if(self.delay_ms) {

--- a/test/shmock.js
+++ b/test/shmock.js
@@ -75,7 +75,8 @@ describe("shmock", function() {
             if (error) return done(error);
             handler.isDone.should.be.ok;
             done();
-          });     
+
+          });
         });
       });
     });
@@ -139,6 +140,12 @@ describe("shmock", function() {
       mock.post("/get").set("Content-Type", "application/json").reply(200);
 
       test.post("/get").set("Content-Type", "application/json").send({}).expect(200, done);
+    });
+
+    it("Should allow to specify response headers", function(done) {
+      mock.post("/get").reply(200,'Hello world',{'X-my-header':'My header value'});
+
+      test.post("/get").expect('X-my-header', 'My header value').expect(200, done);
     });
 
     it("Should be able to wait a specificed number of ms for expectation to be met", function(done) {


### PR DESCRIPTION
API was taken from the same way nock does it (https://github.com/pgte/nock#specifying-reply-headers)